### PR TITLE
fix: rename app name on constant to `auctions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2024-11-08
+
+### Fixed
+- Modified Topsort's app name to get settings from VTEX
+
 ## [1.0.1] - 2024-10-28
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "topsortpartnercl",
   "name": "auctions",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "title": "Topsort's Auctions Integration",
   "description": "Topsort's Fork of VTEX search resolver to run auctions in Topsort.",
   "credentialType": "absolute",
@@ -12,10 +12,12 @@
   "billingOptions": {
     "type": "free",
     "support": {
-        "email": "support@topsort.com",
-        "url": "https://docs.topsort.com/overview/"
+      "email": "support@topsort.com",
+      "url": "https://docs.topsort.com/overview/"
     },
-    "availableCountries": ["*"]
+    "availableCountries": [
+      "*"
+    ]
   },
   "dependencies": {
     "vtex.messages": "1.x",

--- a/node/package.json
+++ b/node/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^12.0.0",
     "@types/qs": "^6.5.1",
     "@types/ramda": "^0.26.21",
-    "@vtex/api": "6.47.0",
+    "@vtex/api": "6.48.0",
     "@vtex/tsconfig": "^0.6.0",
     "eslint": "^5.15.3",
     "eslint-config-vtex": "^10.1.0",

--- a/node/resolvers/search/constants.ts
+++ b/node/resolvers/search/constants.ts
@@ -15,4 +15,4 @@ export const FILTER_TITLE_SEP = '_'
 export const CATEGORY_SEGMENT = 'c'
 export const FULL_TEXT_SEGMENT = 'ft'
 
-export const APP_NAME = 'topsortpartnercl.search-resolver'
+export const APP_NAME = 'topsortpartnercl.auctions'

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -780,10 +780,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@6.47.0":
-  version "6.47.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
-  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
+"@vtex/api@6.48.0":
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.48.0.tgz#67f9f11d197d543d4f854b057d31a8d6999241e9"
+  integrity sha512-mAdT7gbV0/BwiuqUkNH1E7KZqTUczT5NbBBZcPJq5kmTr73PUjbR9wh//70ryJo2EAdHlqIgqgwsCVpozenlhg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -4684,7 +4684,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
This PR changes the app name in the constant file from `search-resolver` to `auctions`, as part of enabling the application to read the settings from the `topsortpartnercl.auctions` app.