### PR TITLE
feat: improve keyword auctions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.3.0]
+
+### Added
+- Support for encoded characters
+- Improve auction rate on keywords
+
 ## [2.2.6]
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "topsortpartnercl",
   "name": "auctions",
-  "version": "2.2.6",
+  "version": "2.3.0",
   "title": "Topsort's Auctions Integration",
   "description": "Topsort's Fork of VTEX search resolver to run auctions in Topsort.",
   "credentialType": "absolute",

--- a/node/clients/intelligent-search-api.ts
+++ b/node/clients/intelligent-search-api.ts
@@ -145,7 +145,7 @@ export class IntelligentSearchApi extends ExternalClient {
     for (const arg of queryArgs) {
       if (!forbiddenKeywords.includes(arg.value)) {
         topsortQueryArgParams.push({
-          type: arg.key === 'ft'
+          type: arg.key === 'ft' || arg.key === 'b'
             ? 'query'
             : arg.key === 'c'
               ? 'category'
@@ -224,7 +224,7 @@ export class IntelligentSearchApi extends ExternalClient {
                 {
                   type: "listings",
                   slots: params.sponsoredCount || 2,
-                  searchQuery: arg.value
+                  searchQuery: decodeURIComponent(arg.value)
                 },
               ],
             };


### PR DESCRIPTION
… improve auction rate on keywords in changelog


1. We treat the b parameter as the search query.
2. We decode search strings. This step was previously added, but we removed it because it was causing problems.