### PR TITLE
chore: bump version to 2.3.2, update changelog to include product IDs in search auctions and 'ft' as a query argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.3.2]
+
+### Added
+- Include product ids on search auctions
+- Include ft as a query arg key for search
+
 ## [2.3.1]
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "topsortpartnercl",
   "name": "auctions",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "title": "Topsort's Auctions Integration",
   "description": "Topsort's Fork of VTEX search resolver to run auctions in Topsort.",
   "credentialType": "absolute",

--- a/node/clients/intelligent-search-api.ts
+++ b/node/clients/intelligent-search-api.ts
@@ -145,7 +145,7 @@ export class IntelligentSearchApi extends ExternalClient {
     for (const arg of queryArgs) {
       if (!forbiddenKeywords.includes(arg.value)) {
         topsortQueryArgParams.push({
-          type: arg.key === 'ft' || arg.key === 'b'
+          type: (arg.key === 'ft' || arg.key === 'b')
             ? 'query'
             : arg.key === 'c'
               ? 'category'
@@ -228,7 +228,10 @@ export class IntelligentSearchApi extends ExternalClient {
                 {
                   type: "listings",
                   slots: params.sponsoredCount || 2,
-                  searchQuery: decodeURIComponent(arg.value)
+                  searchQuery: decodeURIComponent(arg.value),
+                  products: {
+                    ids: result.products.map((product: any) => product.productId)
+                  }
                 },
               ],
             };


### PR DESCRIPTION
in search auctions and 'ft' as a query argument

- Include product ids on search auctions
- Include ft as a query arg key for search