### PR TITLE
feat: decode query

### DIFF
--- a/node/clients/intelligent-search-api.ts
+++ b/node/clients/intelligent-search-api.ts
@@ -270,7 +270,7 @@ export class IntelligentSearchApi extends ExternalClient {
     }
 
     if (params.query && params.query.length > 0) {
-      topsortQuery.searchQuery = params.query
+      topsortQuery.searchQuery = decodeQuery(params.query)
     }
 
     if (


### PR DESCRIPTION
When searching "probioticos" it gave different winners than "probióticos"

Implemented search query decoding to parse special characters


https://www.larebajavirtual.com/probioticos?_q=probioticos&map=ft
https://www.larebajavirtual.com/probióticos?_q=probióticos&map=ft

Fixed in https://agustintest2--copservir.myvtex.com/probi%C3%B3ticos?_q=probi%C3%B3ticos&map=ft